### PR TITLE
daemon: support 3rd party containerd shim v2 runtimes

### DIFF
--- a/daemon/runtime_unix.go
+++ b/daemon/runtime_unix.go
@@ -36,13 +36,18 @@ func configureRuntimes(conf *config.Config) {
 		conf.Runtimes = make(map[string]types.Runtime)
 	}
 	conf.Runtimes[config.LinuxV1RuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: defaultV1ShimConfig(conf, defaultRuntimeName)}
-	conf.Runtimes[config.LinuxV2RuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: defaultV2ShimConfig(conf, defaultRuntimeName)}
+	conf.Runtimes[config.LinuxV2RuntimeName] = types.Runtime{Path: defaultRuntimeName, Shim: defaultV2ShimConfig(conf, linuxShimV2, defaultRuntimeName)}
 	conf.Runtimes[config.StockRuntimeName] = conf.Runtimes[config.LinuxV2RuntimeName]
 }
 
-func defaultV2ShimConfig(conf *config.Config, runtimePath string) *types.ShimConfig {
+func defaultV2ShimConfig(conf *config.Config, shimRuntime, runtimePath string) *types.ShimConfig {
+	// non-empty runtime path means using an OCI compatible runtime implementation.
+	// otherwise a shim v2 compatible runtime will be set
+	if runtimePath != "" {
+		shimRuntime = linuxShimV2
+	}
 	return &types.ShimConfig{
-		Binary: linuxShimV2,
+		Binary: shimRuntime,
 		Opts: &v2runcoptions.Options{
 			BinaryName:    runtimePath,
 			Root:          filepath.Join(conf.ExecRoot, "runtime-"+defaultRuntimeName),
@@ -106,7 +111,7 @@ func (daemon *Daemon) initRuntimes(runtimes map[string]types.Runtime) (err error
 			}
 		}
 		if rt.Shim == nil {
-			rt.Shim = defaultV2ShimConfig(daemon.configStore, rt.Path)
+			rt.Shim = defaultV2ShimConfig(daemon.configStore, name, rt.Path)
 		}
 	}
 	return nil
@@ -144,7 +149,7 @@ func (daemon *Daemon) getRuntime(name string) (*types.Runtime, error) {
 	}
 
 	if rt.Shim == nil {
-		rt.Shim = defaultV2ShimConfig(daemon.configStore, rt.Path)
+		rt.Shim = defaultV2ShimConfig(daemon.configStore, name, rt.Path)
 	}
 
 	if rt.Shim.Binary == linuxShimV1 {


### PR DESCRIPTION
**- What I did**

Support 3rd party containerd shim v2 runtimes

 Now dockerd support other OCI runtimes other than runc,
    but can't set other containerd shim v2 implementations
    like io.containerd.kata.v2.

This commit will support setting these two types of runtime.

**- How I did it**

CommonUnixConfig.Runtimes has a type of map[string]types.Runtime,
For containerd shim v2 runtime other than io.containerd.runc.v2,
empty path in types.Runtime may expected to be empty,
and only the runtime name will be passed to contained.

So this commit uses the path property in types.Runtime to decide
which type of runtime should be set.

- Empty path means setting other shim v2 runtime by its name,
  e.g. io.containerd.kata.v2
- Non-empty means an OCI runtime like runc for io.containerd.runc.v2,
  since path for an OCI runtime is mandatory.

**- How to verify it**

Docker daemon config:

```json
{
  "debug": true,
  "runtimes": {
    "another-runc": {
        "path": "/usr/bin/runc"
    },
    "io.containerd.kata.v2": {
    }
  }
}

```

OCI runtime:
```
$ docker run -it --runtime another-runc  docker.io/library/busybox:latest date
```
io.containerd.kata.v2:
```
$ docker run -it --runtime io.containerd.kata.v2  docker.io/library/busybox:latest date
```

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->
support 3rd party shim v2 runtimes

**- A picture of a cute animal (not mandatory but encouraged)**

